### PR TITLE
Add shield support for Elastic IPs

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -1469,6 +1469,31 @@ class NetworkAddress(query.QueryResourceManager):
         date = None
         dimension = None
         config_type = "AWS::EC2::EIP"
+        
+    @property
+    def generate_arn(self):
+        if self._generate_arn is None:
+            self._generate_arn = functools.partial(
+                generate_arn,
+                self.get_model().service,
+                region=self.config.region,
+                account_id=self.account_id,
+                resource_type='eip-allocation',
+                separator='/')
+        return self._generate_arn
+
+    def get_arn(self, r):
+        return self.generate_arn(r[self.get_model().id])
+    
+    def get_arns(self, resource_set):
+        arns = []
+        for r in resource_set:
+            _id = r[self.get_model().id]
+            arns.append(self.generate_arn(_id))
+        return arns
+
+NetworkAddress.filter_registry.register('shield-enabled', IsShieldProtected)
+NetworkAddress.action_registry.register('set-shield', SetShieldProtection)
 
 
 @NetworkAddress.action_registry.register('release')

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -36,6 +36,7 @@ from c7n.utils import (
 from botocore.exceptions import ClientError
 from c7n.resources.shield import IsShieldProtected, SetShieldProtection
 
+
 @resources.register('vpc')
 class Vpc(query.QueryResourceManager):
 
@@ -1469,7 +1470,7 @@ class NetworkAddress(query.QueryResourceManager):
         date = None
         dimension = None
         config_type = "AWS::EC2::EIP"
-        
+
     @property
     def generate_arn(self):
         if self._generate_arn is None:
@@ -1484,13 +1485,14 @@ class NetworkAddress(query.QueryResourceManager):
 
     def get_arn(self, r):
         return self.generate_arn(r[self.get_model().id])
-    
+
     def get_arns(self, resource_set):
         arns = []
         for r in resource_set:
             _id = r[self.get_model().id]
             arns.append(self.generate_arn(_id))
         return arns
+
 
 NetworkAddress.filter_registry.register('shield-enabled', IsShieldProtected)
 NetworkAddress.action_registry.register('set-shield', SetShieldProtection)

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import itertools
 import operator
 import zlib
-
+import functools
 import jmespath
 
 from botocore.exceptions import ClientError as BotoClientError
@@ -32,9 +32,9 @@ from c7n.filters.locked import Locked
 from c7n import query, resolver
 from c7n.manager import resources
 from c7n.utils import (
-    chunks, local_session, type_schema, get_retry, parse_cidr)
+    chunks, local_session, type_schema, get_retry, parse_cidr, generate_arn)
 from botocore.exceptions import ClientError
-
+from c7n.resources.shield import IsShieldProtected, SetShieldProtection
 
 @resources.register('vpc')
 class Vpc(query.QueryResourceManager):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ jsonschema>=2.5.1
 PyYAML>=3.12
 tabulate>=0.7.7
 jsonpatch>=1.2.1
+futures==3.1.1

--- a/tools/c7n_azure/c7n_azure/resources/network_security_group.py
+++ b/tools/c7n_azure/c7n_azure/resources/network_security_group.py
@@ -209,10 +209,9 @@ class RulesAction(BaseAction):
             nsg_name = nsg['name']
             resource_group = nsg['resourceGroup']
             for rule in nsg['properties']['securityRules']:
-                self.manager.log.info(
-                    'Updating access to \'%s\' for security rule '
-                    '\'%s\' in resource group \'%s\''.format(
-                        self.access_action, rule['name'], resource_group))
+                self.manager.log.info("Updating access to '%s' for security rule "
+                                      "'%s' in resource group '%s'",
+                                      self.access_action, rule['name'], resource_group)
                 rule['properties']['access'] = self.access_action
                 self.manager.get_client().security_rules.create_or_update(
                     resource_group,

--- a/tools/c7n_mailer/c7n_mailer/utils.py
+++ b/tools/c7n_mailer/c7n_mailer/utils.py
@@ -220,9 +220,13 @@ def resource_format(resource, resource_type):
             resource['CacheClusterCreateTime'],
             resource['CacheClusterStatus'])
     elif resource_type == 'cache-snapshot':
+        cid = resource.get('CacheClusterId')
+        if cid is None:
+            cid = ', '.join([
+                ns['CacheClusterId'] for ns in resource['NodeSnapshots']])
         return "name: %s cluster: %s source: %s" % (
             resource['SnapshotName'],
-            resource['CacheClusterId'],
+            cid,
             resource['SnapshotSource'])
     elif resource_type == 'redshift-snapshot':
         return "name: %s db: %s" % (

--- a/tools/c7n_org/README.md
+++ b/tools/c7n_org/README.md
@@ -76,3 +76,26 @@ output
     |- account-2
 ...
 ```
+
+# Selecting accounts and policy for execution
+
+You can filter the accounts to be run against by either passing the account name or id
+via the `-a` flag, which can be specified multiple times.
+
+Groups of accounts can also be selected for execution by specifying the `-t` tag filter.
+Account tags are specified in the config file. ie given the above accounts config file
+you can specify all prod accounts with `-t type:prod`.
+
+You can specify which policies to use for execution by either specifying `-p` or selecting
+groups of policies via their tags with `-l`.
+
+
+See `c7n-org run --help` for more information.
+
+# Other commands
+
+c7n-org also supports running arbitrary scripts against accounts via the run command, which
+exports standard AWS SDK credential information into the process environment before executing.
+
+c7n-org also supports generating reports for a given policy execution across accounts via
+the `c7n-org report` subcommand.


### PR DESCRIPTION
This adds support to create shield protection for Elastic IPs.

Example:
```
policies:
    - name: shield-protect-eip
      resource: network-addr
      filters:
        - type: shield-enabled
          state: false
      actions:
        - type: set-shield
          state: true
```